### PR TITLE
Remove jitpack.de

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
-        maven { url "https://jitpack.de" }
         maven { url "https://jitpack.io" }
         google()
     }


### PR DESCRIPTION
jitpack.de doesn't seem to exist and it blocks the buld by f-droid
because it errors out on unknown maven repositories.