### PR TITLE
fixed omnibox input type

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -213,7 +213,7 @@
                 android:selectAllOnFocus="true"
                 android:completionThreshold="1"
                 android:imeOptions="actionGo"
-                android:inputType="textWebEditText"
+                android:inputType="textUri"
                 android:maxLines="1"
                 android:ellipsize="end"
                 android:background="?attr/colorPrimary"/>
@@ -308,4 +308,3 @@
     </LinearLayout>
 
 </de.baumann.browser.View.SwitcherPanel>
-


### PR DESCRIPTION
I fixed the omnibox input type such that it accepts uris. When using keyboards like switfkey in my case I ended up writing "Github. com" instead of "github.com" because of auto correction. With this fix swiftkey now accepts urls.