### PR TITLE
Intial config for travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: android
+android:
+  components:
+    - tools
+    - platform-tools
+    - tools
+
+before_install:
+  - yes | sdkmanager "platforms;android-27" "build-tools;27.0.3"
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache
+script:
+  - ./gradlew build


### PR DESCRIPTION
This travis config builds the project for every new commit. Furthermore pull requests should be checked.
You just need to login in travis-ci.org and enable travis for this project.
Releases are not included yet.

Related to  #108 