### PR TITLE
Changelog correction and help section v 5.9

### DIFF
--- a/app/src/main/res/values-pl/strings_dialogs.xml
+++ b/app/src/main/res/values-pl/strings_dialogs.xml
@@ -4,7 +4,19 @@
 
     <string name="changelog_title">Dziennik zmian</string>
     <string name="changelog_dialog">
+        &lt;i>Strona projektu na GitHubie: https://github.com/scoute-dich/Browser&lt;br>
+        Dziennik zmian (en): https://github.com/scoute-dich/browser/blob/master/CHANGELOG.md&lt;/i>&lt;br>&lt;br>
 
+        &lt;b>Wersja: 5.7&lt;/b>&lt;br>
+        Pamiętaj o sprawdzeniu sekcji \"Pomoc\", aby zapoznać się z funkcjami apki.&lt;br>&lt;br>
+
+        \u25AA poprawiono: tłumaczenie chińskie (dzięki @YC L)&lt;br>
+        \u25AA poprawiono: tłumaczenie rosyjskie (dzięki @Vladimir Kosolapov)&lt;br>
+        \u25AA dodano: język polski (dzięki @gh-pmjm)&lt;br>
+        \u25AA dodano: język duński (dzięki @gHeimen Stoffels)&lt;br>
+        \u25AA nowość: ikona adaptacyjna
+    </string>
+    
    <string name="startpage_title">Strona domowa</string>
     <string name="startpage_dialog">Tu znajdziesz dostęp do wszystkich twoich danych - zapisanych stron na podglądzie domowym, zakładki, historię przeglądania, zapisane dane logowania oraz zintegrowane pliki. W Preferencjach możesz ustalić jakie elementy będą tutaj wyświetlane.</string>
 
@@ -14,8 +26,8 @@
     <string name="toolbar_title">Panel narzędziowy</string>
     <string name="toolbar_dialog">Na dole ekranu znajdziesz panel narzędziowy. Służy on do wpisywania adresów witryn, szybkiego wyszukiwania, a także zawiera przyciski odświeżenia i menu. Dłuższe przytrzymanie ikonki menu (trzykropek) spowoduje otwarcie panelu Szybkich preferencji. Wykonanie gestu palcem w górę na belce panelu narzędziowego wywoła podgląd otwartych kart. Przesunięciem palcem w prawo lub w lewo po belce panelu narzędziowego spowoduje szybkie przełączenie między aktywnymi kartami.</string>
 
-    <string name="tab_title">Pogląd kart</string>
-    <string name="tab_dialog">Dotknij okienka karty, aby do niej przejść. Dotknięcie belki panelu narzędziowego lub wykonanie gestu palcem w dół spowoduje ukrycie Podglądu kart. Aby zamknąć wybraną kartę wykonaj na okienku podglądu tej karty gest palcem w górę lub w dół. W panelu Podglądu kart znajdziesz też przycisk plusa, otwierający nową pustą kartę jako piorytetową.</string>
+    <string name="tab_title">Podgląd kart</string>
+    <string name="tab_dialog">Dotknij okienka karty, aby do niej przejść. Dotknięcie belki panelu narzędziowego lub wykonanie gestu palcem w dół spowoduje ukrycie Podglądu kart. Aby zamknąć wybraną kartę wykonaj na okienku podglądu tej karty gest palcem w górę lub w dół. W panelu Podglądu kart znajdziesz też przycisk plusa, otwierający nową pustą kartę jako priorytetową.</string>
 
     <string name="menu_title">Menu</string>
     <string name="menu_dialog">Zarządzaj otwartymi kartami, udostępniaj witryny lub zachowuj ich zawartość za pomocą menu kontekstowego. Menu to, tak jak każde inne, możesz odwołać przyciskiem Wstecz, dotykając obszaru poza Menu lub wykonać gest palcem w dół.</string>


### PR DESCRIPTION
The help dialogs were marged in Changelog section due to lack of "changelog_dialog" string ending.