### PR TITLE
Fixed custom search engine

### DIFF
--- a/app/src/main/java/de/baumann/browser/View/SearchEngineListPreference.java
+++ b/app/src/main/java/de/baumann/browser/View/SearchEngineListPreference.java
@@ -61,7 +61,7 @@ public class SearchEngineListPreference extends ListPreference {
                 } else if (!BrowserUnit.isURL(domain)) {
                     NinjaToast.show(getContext(), R.string.toast_invalid_domain);
                 } else {
-                    sp.edit().putString(getContext().getString(R.string.sp_search_engine), "7").commit();
+                    sp.edit().putString(getContext().getString(R.string.sp_search_engine), "8").commit();
                     sp.edit().putString(getContext().getString(R.string.sp_search_engine_custom), domain).commit();
 
                     hideSoftInput(editText);


### PR DESCRIPTION
While adding the Qwant search engine in #243 I forgot to increment the ID of the custom search engine, thus the custom search engine is not selectable. Sorry about that, this change should fix that problem. 