### PR TITLE
Fixed long press-menu and added automatic file extension of downloadable files

### DIFF
--- a/app/src/main/java/de/baumann/browser/Activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/Activity/BrowserActivity.java
@@ -2977,6 +2977,11 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
                         editTitle.setHint(R.string.dialog_title_hint);
                         editTitle.setText(HelperUnit.fileName(ninjaWebView.getUrl()));
 
+                        String extension = url.substring(url.lastIndexOf("."));
+                        if(extension.length() <= 8) {
+                            editExtension.setText(extension);
+                        }
+
                         builder.setView(dialogView);
                         builder.setTitle(R.string.menu_edit);
                         builder.setPositiveButton(R.string.app_ok, new DialogInterface.OnClickListener() {

--- a/app/src/main/java/de/baumann/browser/Browser/NinjaClickHandler.java
+++ b/app/src/main/java/de/baumann/browser/Browser/NinjaClickHandler.java
@@ -15,6 +15,6 @@ public class NinjaClickHandler extends Handler {
     @Override
     public void handleMessage(Message message) {
         super.handleMessage(message);
-        webView.getBrowserController().onLongPress(message.getData().getString("url"));
+        webView.getBrowserController().onLongPress(message.getData().getString("src"));
     }
 }


### PR DESCRIPTION
Use 'src' instead of 'url' to fix problems with the long-press menu on images (or similar objects). Also added a feature to guess the file type which will be downloaded (when selected from long-press menu), this may not work with every download.
This solves #238 and a problem from #225.