### PR TITLE
Do not add lines starting with "#" to hosts

### DIFF
--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -152,7 +152,6 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
     private Javascript javaHosts;
     private Cookie cookieHosts;
     private Remote remote;
-    private boolean desktopMode=false;
 
     private long newIcon;
     private boolean filter;
@@ -1117,9 +1116,9 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
         });
 
         Chip chip_location = dialogView.findViewById(R.id.chip_location);
-        chip_location.setChecked(desktopMode);
+        chip_location.setChecked(ninjaWebView.isDesktopMode());
         chip_location.setOnClickListener(v -> {
-            toggleDesktopMode(ninjaWebView);
+            ninjaWebView.toggleDesktopMode();
             dialog.cancel();
         });
 
@@ -1667,7 +1666,7 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
         GridItem item_32 = new GridItem(0, getString(R.string.menu_download),  0);
         GridItem item_33 = new GridItem(0, getString(R.string.setting_label),  0);
         GridItem item_34;
-        if (desktopMode) item_34 = new GridItem(0,getString((R.string.menu_mobileView)),0);
+        if (ninjaWebView.isDesktopMode()) item_34 = new GridItem(0,getString((R.string.menu_mobileView)),0);
         else item_34 = new GridItem(0,getString((R.string.menu_desktopView)),0);
 
         GridItem item_35;
@@ -1691,7 +1690,7 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
                 searchOnSite();
             } else if (position == 1) {
                 dialog_overflow.cancel();
-                toggleDesktopMode(ninjaWebView);
+                ninjaWebView.toggleDesktopMode();
             } else if (position == 2) {
                 if (sp.getBoolean("sp_invert", false)) {
                     sp.edit().putBoolean("sp_invert", false).apply();
@@ -1981,25 +1980,5 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
         return list.get(index);
     }
 
-    public void toggleDesktopMode(WebView webView) {
-        desktopMode=!desktopMode;
-        String newUserAgent = webView.getSettings().getUserAgentString();
-        if (desktopMode) {
-            try {
-                String ua = webView.getSettings().getUserAgentString();
-                String androidOSString = webView.getSettings().getUserAgentString().substring(ua.indexOf("("), ua.indexOf(")") + 1);
-                newUserAgent = webView.getSettings().getUserAgentString().replace(androidOSString, "(X11; Linux x86_64)");
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        } else {
-            sp = PreferenceManager.getDefaultSharedPreferences(context);
-            newUserAgent = sp.getString("userAgent", "");
-        }
-        webView.getSettings().setUserAgentString(newUserAgent);
-        webView.getSettings().setUseWideViewPort(desktopMode);
-        webView.getSettings().setSupportZoom(desktopMode);
-        webView.getSettings().setLoadWithOverviewMode(desktopMode);
-        webView.reload();
-    }
+
 }

--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -1080,14 +1080,14 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
         });
 
         Chip chip_adBlock = dialogView.findViewById(R.id.chip_adBlock);
-        chip_adBlock.setChecked(sp.getBoolean(getString(R.string.sp_ad_block), true));
+        chip_adBlock.setChecked(sp.getBoolean("sp_ad_block", true));
         chip_adBlock.setOnClickListener(v -> {
-            if (sp.getBoolean(getString(R.string.sp_ad_block), true)) {
+            if (sp.getBoolean("sp_ad_block", true)) {
                 chip_adBlock.setChecked(false);
-                sp.edit().putBoolean(getString(R.string.sp_ad_block), false).apply();
+                sp.edit().putBoolean("sp_ad_block", false).apply();
             } else {
                 chip_adBlock.setChecked(true);
-                sp.edit().putBoolean(getString(R.string.sp_ad_block), true).apply();
+                sp.edit().putBoolean("sp_ad_block", true).apply();
             }
         });
 

--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -409,6 +409,8 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
 
         updateOmniBox();
 
+        HelperUnit.initRendering(ninjaWebView, context);
+
         if (sp.getBoolean("hideToolbar", true)) {
             ObjectAnimator animation = ObjectAnimator.ofFloat(bottomAppBar, "translationY", 0);
             animation.setDuration(getResources().getInteger(android.R.integer.config_shortAnimTime));

--- a/app/src/main/java/de/baumann/browser/browser/AdBlock.java
+++ b/app/src/main/java/de/baumann/browser/browser/AdBlock.java
@@ -36,6 +36,7 @@ public class AdBlock {
                 BufferedReader reader = new BufferedReader(in) ;
                 String line;
                 while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("#"))  continue;
                     hosts.add(line.toLowerCase(locale));
                 }
                 in.close();

--- a/app/src/main/java/de/baumann/browser/browser/AdBlock.java
+++ b/app/src/main/java/de/baumann/browser/browser/AdBlock.java
@@ -28,6 +28,31 @@ public class AdBlock {
     @SuppressLint("ConstantLocale")
     private static final Locale locale = Locale.getDefault();
 
+
+    public static String getHostsDate(Context context){
+        File file = new File(context.getDir("filesdir", Context.MODE_PRIVATE) + "/"+FILE);
+        String date="";
+        if (!file.exists()) {
+            return "";
+        }
+            try {
+                FileReader in = new FileReader(file);
+                BufferedReader reader = new BufferedReader(in) ;
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.contains("Date:"))  {
+                        date="hosts.txt " + line.substring(2);
+                        in.close();
+                        break;
+                    }
+                }
+                in.close();
+            } catch (IOException i) {
+                Log.w("browser", "Error loading hosts", i);
+            }
+        return date;
+    }
+
     private static void loadHosts(final Context context) {
         Thread thread = new Thread(() -> {
             try {

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Start.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Start.java
@@ -9,6 +9,7 @@ import de.baumann.browser.activity.Whitelist_Cookie;
 import de.baumann.browser.activity.Whitelist_Javascript;
 import de.baumann.browser.R;
 import de.baumann.browser.activity.Whitelist_Remote;
+import de.baumann.browser.browser.AdBlock;
 
 @SuppressWarnings("ConstantConditions")
 public class Fragment_settings_Start extends PreferenceFragmentCompat {
@@ -16,6 +17,9 @@ public class Fragment_settings_Start extends PreferenceFragmentCompat {
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.preference_start, rootKey);
+
+        findPreference("sp_ad_block").setSummary(getString(R.string.setting_summary_adblock)+"\n\n"+AdBlock.getHostsDate(getContext()));
+
         findPreference("start_java").setOnPreferenceClickListener(preference -> {
             Intent intent = new Intent(getActivity(), Whitelist_Javascript.class);
             requireActivity().startActivity(intent);

--- a/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
+++ b/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
@@ -140,7 +140,7 @@ public class NinjaWebView extends WebView implements AlbumController {
         webSettings.setBuiltInZoomControls(true);
         webSettings.setDisplayZoomControls(false);
         webSettings.setSupportMultipleWindows(true);
-        webViewClient.enableAdBlock(sp.getBoolean(context.getString(R.string.sp_ad_block), true));
+        webViewClient.enableAdBlock(sp.getBoolean("sp_ad_block", true));
         webSettings.setTextZoom(Integer.parseInt(Objects.requireNonNull(sp.getString("sp_fontSize", "100"))));
         webSettings.setDomStorageEnabled(sp.getBoolean(("sp_remote"), false));
         webSettings.setBlockNetworkImage(!sp.getBoolean(context.getString(R.string.sp_images), true));

--- a/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
+++ b/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
@@ -57,7 +57,7 @@ public class NinjaWebView extends WebView implements AlbumController {
     }
 
     private Context context;
-
+    private boolean desktopMode;
     private AlbumItem album;
     private NinjaWebViewClient webViewClient;
     private NinjaWebChromeClient webChromeClient;
@@ -92,7 +92,7 @@ public class NinjaWebView extends WebView implements AlbumController {
 
         this.context = context;
         this.foreground = false;
-
+        this.desktopMode=false;
         this.javaHosts = new Javascript(this.context);
         this.remoteHosts = new Remote(this.context);
         this.cookieHosts = new Cookie(this.context);
@@ -243,5 +243,32 @@ public class NinjaWebView extends WebView implements AlbumController {
         Message click = clickHandler.obtainMessage();
         click.setTarget(clickHandler);
         requestFocusNodeHref(click);
+    }
+
+    public boolean isDesktopMode() {
+        return desktopMode;
+    }
+
+    public void toggleDesktopMode() {
+
+        desktopMode=!desktopMode;
+        String newUserAgent = getSettings().getUserAgentString();
+        if (desktopMode) {
+            try {
+                String ua = getSettings().getUserAgentString();
+                String androidOSString = getSettings().getUserAgentString().substring(ua.indexOf("("), ua.indexOf(")") + 1);
+                newUserAgent = getSettings().getUserAgentString().replace(androidOSString, "(X11; Linux x86_64)");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
+            sp = PreferenceManager.getDefaultSharedPreferences(context);
+            newUserAgent = sp.getString("userAgent", "");
+        }
+        getSettings().setUserAgentString(newUserAgent);
+        getSettings().setUseWideViewPort(desktopMode);
+        getSettings().setSupportZoom(desktopMode);
+        getSettings().setLoadWithOverviewMode(desktopMode);
+        reload();
     }
 }

--- a/app/src/main/res/xml/preference_start.xml
+++ b/app/src/main/res/xml/preference_start.xml
@@ -27,7 +27,7 @@
     <PreferenceCategory android:title="@string/setting_title_adblock">
 
         <CheckBoxPreference
-            android:key="@string/sp_ad_block"
+            android:key="sp_ad_block"
             android:defaultValue="true"
             android:summary="@string/setting_summary_adblock"/>
 


### PR DESCRIPTION
I don`t think we need to load lines starting with "#".
This reduces hosts by a few thousand lines.
I did not remove it at download time, so the downloaded file still has the comments, e.g. one could read and display the date of the file if needed.