### PR TITLE
Remember JavaScript and remote content setting in bookmarks

### DIFF
--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -1866,6 +1866,14 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
                     TextInputLayout edit_PW_layout = dialogViewSubMenu.findViewById(R.id.edit_PW_layout);
                     ImageView ib_icon = dialogViewSubMenu.findViewById(R.id.edit_icon);
                     ib_icon.setVisibility(View.VISIBLE);
+
+                    Chip chip_desktopMode = dialogViewSubMenu.findViewById(R.id.edit_bookmark_desktopMode);
+                    Chip chip_javascript = dialogViewSubMenu.findViewById(R.id.edit_bookmark_Javascript);
+                    Chip chip_remoteContent = dialogViewSubMenu.findViewById(R.id.edit_bookmark_RemoteContent);
+                    chip_desktopMode.setVisibility(View.VISIBLE);
+                    chip_javascript.setVisibility(View.VISIBLE);
+                    chip_remoteContent.setVisibility(View.VISIBLE);
+
                     edit_title_layout.setVisibility(View.VISIBLE);
                     edit_userName_layout.setVisibility(View.GONE);
                     edit_PW_layout.setVisibility(View.GONE);
@@ -1892,6 +1900,11 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
                             dialogFilter.cancel();
                         });
                     });
+
+                    chip_desktopMode.setChecked((icon&16)==16);
+                    chip_javascript.setChecked(!((icon&32)==32));
+                    chip_remoteContent.setChecked(!((icon&64)==64));
+
                     newIcon = icon&15;
 
                     HelperUnit.setFilterIcons(ib_icon, newIcon);
@@ -1902,7 +1915,7 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
                         RecordAction action = new RecordAction(context);
                         action.open(true);
                         action.deleteURL(url, RecordUnit.TABLE_BOOKMARK);
-                        newIcon=(icon&112)+newIcon; //keep bits for desktop mode, javascript, and remote content
+                        newIcon=newIcon+(long) (chip_desktopMode.isChecked()?16:0)+(long)(chip_javascript.isChecked()?0:32)+(long)(chip_remoteContent.isChecked()?0:64);
                         action.addBookmark(new Record(edit_title.getText().toString(), url, newIcon, 0));
                         action.close();
                         updateAutoComplete();

--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -751,6 +751,7 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
 
                 listView.setAdapter(adapter);
                 adapter.notifyDataSetChanged();
+                listView.setSelection(0);
                 filter = false;
                 listView.setOnItemClickListener((parent, view, position, id) -> {
 

--- a/app/src/main/java/de/baumann/browser/database/RecordAction.java
+++ b/app/src/main/java/de/baumann/browser/database/RecordAction.java
@@ -136,7 +136,8 @@ public class RecordAction {
         }
         cursor.close();
 
-        if (sortBy.equals("time")){  //eliminate desktop mode when sorting colors
+        if (sortBy.equals("time")){  //ignore desktop mode, JavaScript, and remote content when sorting colors
+            Collections.sort(list, (first, second) -> first.getTitle().compareTo(second.getTitle()));
             Collections.sort(list,(first, second) -> Long.compare(first.getTime()&15, second.getTime()&15));
         }
         return list;

--- a/app/src/main/java/de/baumann/browser/database/RecordAction.java
+++ b/app/src/main/java/de/baumann/browser/database/RecordAction.java
@@ -6,12 +6,10 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.util.Log;
 
 import androidx.preference.PreferenceManager;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -108,7 +106,6 @@ public class RecordAction {
         List<Record> list = new LinkedList<>();
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         String sortBy = Objects.requireNonNull(sp.getString("sort_bookmark", "title"));
-        Log.d("Bookmark",sortBy);
         Cursor cursor;
         cursor = database.query(
                 RecordUnit.TABLE_BOOKMARK,

--- a/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
+++ b/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
@@ -307,7 +307,7 @@ public class BrowserUnit {
                 String title = getBookmarkTitle(line);
                 String url = getBookmarkURL(line);
                 long date = getBookmarkDate(line);
-                if (date>=27) date=11;  //if no color defined yet set it red (27 is max: 16 for desktop mode 11 for color
+                if (date >123) date=11;  //if no color defined yet set it red (123 is max: 11 for color + 16 for desktop mode + 32 for Javascript + 64 for Remote Content
                 if (title.trim().isEmpty() || url.trim().isEmpty()) {
                     continue;
                 }

--- a/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
+++ b/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
@@ -149,15 +149,6 @@ public class NinjaWebView extends WebView implements AlbumController {
         webSettings.setBlockNetworkImage(!sp.getBoolean("sp_images", true));
         webSettings.setGeolocationEnabled(sp.getBoolean("sp_location", false));
 
-        if (javaHosts.isWhite(url) || sp.getBoolean("sp_javascript", true)) {
-            webSettings.setJavaScriptCanOpenWindowsAutomatically(true);
-            webSettings.setJavaScriptEnabled(true);
-        } else {
-            webSettings.setJavaScriptCanOpenWindowsAutomatically(false);
-            webSettings.setJavaScriptEnabled(false);
-        }
-        webSettings.setDomStorageEnabled(remoteHosts.isWhite(url) || sp.getBoolean("sp_remote", true));
-
         CookieManager manager = CookieManager.getInstance();
         if (cookieHosts.isWhite(url) || sp.getBoolean("sp_cookies", true)) {
             manager.setAcceptCookie(true);
@@ -174,24 +165,38 @@ public class NinjaWebView extends WebView implements AlbumController {
             e.printStackTrace();
         }
 
-        if (oldDomain != null) {
-            if (!oldDomain.equals(domain)){
-                //do not change setting if staying within same domain
-                if (javaHosts.isWhite(url) || sp.getBoolean("sp_javascript", true)) {
-                    webSettings.setJavaScriptCanOpenWindowsAutomatically(true);
-                    webSettings.setJavaScriptEnabled(true);
-                } else {
-                    webSettings.setJavaScriptCanOpenWindowsAutomatically(false);
-                    webSettings.setJavaScriptEnabled(false);
-                }
-                webSettings.setDomStorageEnabled(remoteHosts.isWhite(url) || sp.getBoolean("sp_remote", true));
-            }
+        if (!oldDomain.equals(domain)){
+            //do not change setting if staying within same domain
+            setJavaScript(javaHosts.isWhite(url) || sp.getBoolean("sp_javascript", true));
+            setRemoteContent(remoteHosts.isWhite(url) || sp.getBoolean("sp_remote", true));
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             this.setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_YES);         }
 
         oldDomain=domain;
+    }
+
+    public void setOldDomain(String url){
+        String  domain="";
+        try {
+            domain = new URI(url).getHost();
+        } catch (URISyntaxException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        oldDomain=domain;
+    }
+
+    public void setJavaScript(boolean value){
+        WebSettings webSettings = this.getSettings();
+        webSettings.setJavaScriptCanOpenWindowsAutomatically(value);
+        webSettings.setJavaScriptEnabled(value);
+    }
+
+    public void setRemoteContent(boolean value){
+        WebSettings webSettings = this.getSettings();
+        webSettings.setDomStorageEnabled(value);
     }
 
     private synchronized void initAlbum() {

--- a/app/src/main/res/layout/dialog_edit_title.xml
+++ b/app/src/main/res/layout/dialog_edit_title.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -82,4 +83,52 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp">
+    <com.google.android.material.chip.Chip
+        style="@style/Widget.MaterialComponents.Chip.Choice"
+        android:id="@+id/edit_bookmark_desktopMode"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text=""
+        app:chipEndPadding="4dp"
+        app:chipIcon="@drawable/icon_desktop"
+        app:chipIconEnabled="true"
+        app:chipStartPadding="4dp"
+        app:textEndPadding="0dp"
+        app:textStartPadding="0dp" />
+
+    <com.google.android.material.chip.Chip
+        style="@style/Widget.MaterialComponents.Chip.Choice"
+        android:id="@+id/edit_bookmark_Javascript"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text=""
+        app:chipEndPadding="4dp"
+        app:chipIcon="@drawable/icon_java"
+        app:chipIconEnabled="true"
+        app:chipStartPadding="4dp"
+        app:textEndPadding="0dp"
+        app:textStartPadding="0dp" />
+
+    <com.google.android.material.chip.Chip
+        style="@style/Widget.MaterialComponents.Chip.Choice"
+        android:id="@+id/edit_bookmark_RemoteContent"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text=""
+        app:chipEndPadding="4dp"
+        app:chipIcon="@drawable/icon_remote"
+        app:chipIconEnabled="true"
+        app:chipStartPadding="4dp"
+        app:textEndPadding="0dp"
+        app:textStartPadding="0dp" />
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
I reverted some stuff you just added like:
        if (javaHosts.isWhite(url) || sp.getBoolean("sp_javascript", true)) {
            webSettings.setJavaScriptCanOpenWindowsAutomatically(true);
            webSettings.setJavaScriptEnabled(true);
        } else {
            webSettings.setJavaScriptCanOpenWindowsAutomatically(false);
            webSettings.setJavaScriptEnabled(false);
        }
        webSettings.setDomStorageEnabled(remoteHosts.isWhite(url) || sp.getBoolean("sp_remote", true));

Otherwise the JavaScript setting is not kept when browsing within one site.

Also removed if (oldDomain != null) { 
because it will never be null. It is initialized as "".

Bits 5 and 6 now have the (inverted!) JavaScript and remote content setting. Inverted due to backward compatibility with existing bookmarks
