### PR TITLE
Add try catch for Downloadmanager

### DIFF
--- a/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
+++ b/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
@@ -17,6 +17,7 @@ import android.util.Log;
 import android.view.Gravity;
 import android.webkit.CookieManager;
 import android.webkit.URLUtil;
+import android.widget.Toast;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -175,6 +176,7 @@ public class BrowserUnit {
                 }
             } catch (Exception e) {
             System.out.println("Error Downloading File: " + e.toString());
+            Toast.makeText(context, context.getString(R.string.app_error)+e.toString().substring(e.toString().indexOf(":")),Toast.LENGTH_LONG).show();
             e.printStackTrace();
         }
         });

--- a/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
+++ b/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
@@ -148,30 +148,35 @@ public class BrowserUnit {
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context);
         builder.setMessage(text);
         builder.setPositiveButton(R.string.app_ok, (dialog, whichButton) -> {
-            DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
-            String filename = URLUtil.guessFileName(url, contentDisposition, mimeType); // Maybe unexpected filename.
+            try {
+                DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
+                String filename = URLUtil.guessFileName(url, contentDisposition, mimeType); // Maybe unexpected filename.
 
-            CookieManager cookieManager = CookieManager.getInstance();
-            String cookie = cookieManager.getCookie(url);
-            request.addRequestHeader("Cookie", cookie);
-            request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
-            request.setTitle(filename);
-            request.setMimeType(mimeType);
-            request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename);
-            DownloadManager manager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-            assert manager != null;
+                CookieManager cookieManager = CookieManager.getInstance();
+                String cookie = cookieManager.getCookie(url);
+                request.addRequestHeader("Cookie", cookie);
+                request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+                request.setTitle(filename);
+                request.setMimeType(mimeType);
+                request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename);
+                DownloadManager manager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+                assert manager != null;
 
-            if (Build.VERSION.SDK_INT >= 23 && Build.VERSION.SDK_INT < 29) {
-                int hasWRITE_EXTERNAL_STORAGE = context.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-                if (hasWRITE_EXTERNAL_STORAGE != PackageManager.PERMISSION_GRANTED) {
-                    Activity activity = (Activity) context;
-                    HelperUnit.grantPermissionsStorage(activity);
+                if (Build.VERSION.SDK_INT >= 23 && Build.VERSION.SDK_INT < 29) {
+                    int hasWRITE_EXTERNAL_STORAGE = context.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                    if (hasWRITE_EXTERNAL_STORAGE != PackageManager.PERMISSION_GRANTED) {
+                        Activity activity = (Activity) context;
+                        HelperUnit.grantPermissionsStorage(activity);
+                    } else {
+                        manager.enqueue(request);
+                    }
                 } else {
                     manager.enqueue(request);
                 }
-            } else {
-                manager.enqueue(request);
-            }
+            } catch (Exception e) {
+            System.out.println("Error Downloading File: " + e.toString());
+            e.printStackTrace();
+        }
         });
         builder.setNegativeButton(R.string.app_cancel, (dialog, whichButton) -> dialog.cancel());
         AlertDialog dialog = builder.create();


### PR DESCRIPTION
Just had a crash when trying to download a Covid certificate from impfzenten.bayern.
It has a .bin extension but is a .pdf document.

Now it still does not download but at least the app does not crash