### PR TITLE
Do not send de.baumann.browser in "X-Requested-With" header.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <!-- Application -->
     <application
         android:label="@string/app_name"
+        android:name=".FOSSBrowserApplication"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="false"

--- a/app/src/main/java/de/baumann/browser/FOSSBrowserApplication.java
+++ b/app/src/main/java/de/baumann/browser/FOSSBrowserApplication.java
@@ -1,0 +1,20 @@
+package de.baumann.browser;
+import android.app.Application;
+
+public class FOSSBrowserApplication extends Application {
+
+    @Override
+    public String getPackageName() {
+        try {
+            throw new Exception();
+        } catch (Exception e) {
+            StackTraceElement[] elements = e.getStackTrace();
+            for (StackTraceElement element : elements) {
+                if (element.getClassName().startsWith("android.webkit.")) {
+                    return "com.duckduckgo.mobile.android";
+                }
+            }
+        }
+        return super.getPackageName();
+    }
+}


### PR DESCRIPTION
At the moment the browser sends de.baumann.browser in the X-REQUESTED-WITH HTTP header.
As only few people are using this browser we are quite easy to track by fingerprint.
Webview asks for package name and uses it for the header. With this commit there
is an override for getPackageName and if Webview asks it gets com.duckduckgo.mobile.android as name,
a browser which has more than 10 million downloads.