### PR TITLE
Add chip to disable pop-ups as long as staying within same domain

### DIFF
--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -14,7 +14,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.pm.ActivityInfo;
 import android.database.Cursor;
 import android.media.MediaPlayer;
 import android.net.Uri;
@@ -24,12 +23,10 @@ import android.os.Bundle;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.PopupMenu;
-import androidx.constraintlayout.solver.state.State;
 import androidx.preference.PreferenceManager;
 
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.Looper;
 import android.os.Message;
 import android.print.PrintAttributes;
 import android.print.PrintDocumentAdapter;
@@ -73,7 +70,6 @@ import android.webkit.WebBackForwardList;
 import android.webkit.WebChromeClient;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
-import android.webkit.WebViewClient;
 import android.widget.AutoCompleteTextView;
 import android.widget.EditText;
 import android.widget.FrameLayout;
@@ -84,7 +80,6 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 import android.widget.VideoView;
 
 import java.util.LinkedList;
@@ -1030,6 +1025,14 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
                 dialog.cancel();
             });
         }
+
+        Chip chip_allow_popups_WL = dialogView.findViewById(R.id.chip_allow_popups_WL);
+        chip_allow_popups_WL.setChecked(ninjaWebView.getSettings().getJavaScriptCanOpenWindowsAutomatically());
+        chip_allow_popups_WL.setOnClickListener(v -> {
+            if (ninjaWebView.getSettings().getJavaScriptEnabled()) ninjaWebView.getSettings().setJavaScriptCanOpenWindowsAutomatically(chip_allow_popups_WL.isChecked());
+            ninjaWebView.reload();
+            dialog.cancel();
+        });
 
         // CheckBox
 

--- a/app/src/main/res/layout/dialog_toggle.xml
+++ b/app/src/main/res/layout/dialog_toggle.xml
@@ -373,6 +373,40 @@
 
             </RelativeLayout>
 
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="?android:attr/listPreferredItemHeightSmall"
+                android:minHeight="?android:attr/listPreferredItemHeightSmall">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_alignParentStart="true"
+                    android:gravity="center_vertical"
+                    android:text="@string/pop_ups"
+                    android:textAppearance="?attr/textAppearanceBody1"
+                    android:ellipsize="end"
+                    android:includeFontPadding="false"
+                    android:maxLines="1"/>
+
+
+                <com.google.android.material.chip.Chip
+                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    android:id="@+id/chip_allow_popups_WL"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="12dp"
+                    android:text=""
+                    app:chipEndPadding="4dp"
+                    app:chipIcon="@drawable/icon_check"
+                    app:chipIconEnabled="true"
+                    app:chipStartPadding="4dp"
+                    app:textEndPadding="0dp"
+                    app:textStartPadding="0dp"
+                    android:layout_alignParentEnd="true" />
+
+            </RelativeLayout>
+
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="menu_desktopView">Desktop view</string>
     <string name="menu_dayView">Day view</string>
     <string name="menu_nightView">Night view</string>
+    <string name="pop_ups">Pop-ups</string>
 
     <!-- License changelog -->
 


### PR DESCRIPTION
Some pages have pop-ups that come again and again.
This adds a new chip which allows to disable pop-ups for the domain, as long as you stay on the domain.
Default is on, like it was before. So if a site needs popups for GDPR consent etc. it will always be allowed, then the user can disable.