### PR TITLE
Added some database.close() for Favicon Database

### DIFF
--- a/app/src/main/java/de/baumann/browser/database/FaviconHelper.java
+++ b/app/src/main/java/de/baumann/browser/database/FaviconHelper.java
@@ -73,6 +73,7 @@ public class FaviconHelper extends SQLiteOpenHelper {
     public void deleteAllFavicons() throws SQLiteException {
         SQLiteDatabase database = this.getWritableDatabase();
         database.delete(TABLE_FAVICON, null, null);
+        database.close();
     }
 
     public Bitmap getFavicon(String url){
@@ -93,9 +94,11 @@ public class FaviconHelper extends SQLiteOpenHelper {
         if (cursor != null && cursor.moveToFirst()){
             image = cursor.getBlob(1);
             cursor.close();
+            database.close();
             return getBitmap(image);
         }else{
             cursor.close();
+            database.close();
             return null;
         }
     }


### PR DESCRIPTION
I saw some error messages in the logcat, so I fixed it.

But, somewhere there is obviously also a close statement missing for the Ninja4.db:

2021-07-13 16:09:17.965 11063-11078/de.baumann.browser W/SQLiteConnectionPool: A SQLiteConnection object for database '/data/user/0/de.baumann.browser/databases/Ninja4.db' was leaked!  Please fix your application to end transactions in progress properly and to close the database when it is no longer needed.
2021-07-13 16:09:17.965 11063-11078/de.baumann.browser W/System: A resource failed to call close. 
2021-07-13 16:09:17.965 11063-11078/de.baumann.browser W/System: A resource failed to call close. 

Unfortunately I have not found it...