### PR TITLE
Fixed user agent with SwitchTextPreference

### DIFF
--- a/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
+++ b/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
@@ -394,7 +394,7 @@ public class NinjaWebViewClient extends WebViewClient {
 
 
 
-        if(!sp.getBoolean("sp_allowFingerprinting",true)) {
+        if(sp.getBoolean("sp_fingerPrintProtection",false)) {
             view.evaluateJavascript("var test=document.querySelector(\"a[ping]\"); if(test!==null){test.removeAttribute('ping')};", null); //do not allow ping on http only pages (tested with http://tests.caniuse.com)
         }
 

--- a/app/src/main/java/de/baumann/browser/preferences/SwitchTextPreference.java
+++ b/app/src/main/java/de/baumann/browser/preferences/SwitchTextPreference.java
@@ -31,6 +31,7 @@ public class SwitchTextPreference extends Preference
     private String switchKey;
     private String titleText;
     private String valueText;
+    private String hint;
     private boolean switchDefault;
     private String defaultText;
     private EditText valueView;
@@ -51,6 +52,7 @@ public class SwitchTextPreference extends Preference
         switchKey = null;
         switchDefault = true;
         valueText = "";
+        hint = "";
         defaultText="";
 
         //if there are attributes, retrieve them
@@ -62,6 +64,7 @@ public class SwitchTextPreference extends Preference
             switchDefault = valueArray.getBoolean(R.styleable.SwitchTextPreference_switchDefault,true);
             defaultText = valueArray.getString(R.styleable.SwitchTextPreference_defaultText);
             titleText = valueArray.getString(R.styleable.SwitchTextPreference_titleText);
+            hint = valueArray.getString(R.styleable.SwitchTextPreference_hint);
             mIcon=valueArray.getResourceId(R.styleable.SwitchTextPreference_icon,0);
             valueArray.recycle();
         }
@@ -111,7 +114,7 @@ public class SwitchTextPreference extends Preference
 
         //set displays
         rootView.setClickable(false);
-
+        valueView.setHint(hint);
         valueView.setOnTouchListener((v, event) -> {
             valueView.setFocusableInTouchMode(true);
             return false;

--- a/app/src/main/res/layout/switch_text_preference_layout.xml
+++ b/app/src/main/res/layout/switch_text_preference_layout.xml
@@ -33,8 +33,8 @@
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="16dp"
+                android:layout_marginStart="40dp"
+                android:layout_marginEnd="40dp"
                 android:orientation="horizontal"
                 android:layout_gravity="center_vertical">
                 <TextView
@@ -50,33 +50,24 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textSize="16sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="horizontal"
-                android:layout_gravity="center_vertical"
-                android:gravity="center_vertical|start">
                 <EditText
                     android:id="@+id/Switch_Text_Preference_Value_Text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
                     android:imeOptions="actionDone"
                     android:autofillHints=""
-                    android:hint=""
                     android:inputType="text"
-                    android:textSize="16sp"
-                    android:background="@android:color/transparent" />
+                    android:textSize="16sp" />
             </LinearLayout>
+
         </LinearLayout>
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:layout_marginStart="15dip"
-            android:layout_marginEnd="6dip">
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="6dp">
             <TextView
                 android:id="@+id/Switch_Text_Preference_Summary"
                 android:layout_width="match_parent"
@@ -87,5 +78,5 @@
                 android:textColor="?android:attr/textColorSecondary"
                 android:visibility="gone"/>
         </LinearLayout>
-   </LinearLayout>
+    </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -6,6 +6,7 @@
         <attr name="defaultText" format="string"/>
         <attr name="switchKey" format="string"/>
         <attr name="titleText" format="string"/>
+        <attr name="hint" format="string"/>
         <attr name="showSwitch" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/app/src/main/res/xml/preference_filter.xml
+++ b/app/src/main/res/xml/preference_filter.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Preference
+        app:iconSpaceReserved="false"
         android:summary="@string/setting_gesture_hint"/>
 
     <de.baumann.browser.preferences.SwitchTextPreference

--- a/app/src/main/res/xml/preference_setting.xml
+++ b/app/src/main/res/xml/preference_setting.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory android:title="@string/setting_title_browser"> <Preference
             android:key="settings_start"
@@ -39,10 +40,13 @@
         <Preference
             android:key="settings_data"
             android:title="@string/setting_title_data"/>
-        <EditTextPreference
-            android:selectable="true"
+        <de.baumann.browser.preferences.SwitchTextPreference
             android:key="userAgent"
-            android:title="@string/setting_title_userAgent" />
+            app:defaultText=""
+            app:summary=""
+            app:hint="Mozilla/5.0"
+            app:titleText="@string/setting_title_userAgent"
+            app:switchKey="userAgentSwitch" />
         <EditTextPreference
             android:defaultValue="https://www.ecosia.org/search?q="
             android:key="sp_search_engine_custom"


### PR DESCRIPTION
The input line for the user agent was not visible, because you added a transparent background.
I now also added a hint.
Had to revert the changes you made to the layout because it would not fit the layout in preference_settings if no icon is set.
I think you made the change, because the text above the filter settings was indented. I fixed this with
app:iconSpaceReserved="false"