### PR TITLE
Better EditTextSwitchPreference

### DIFF
--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings.java
@@ -40,14 +40,6 @@ public class Fragment_settings extends PreferenceFragmentCompat implements Share
         initSummary(getPreferenceScreen());
 
 
-        androidx.preference.EditTextPreference editTextPreference = findPreference("userAgent");
-        if (editTextPreference!=null) {
-            editTextPreference.setEnabled(true);
-            if ((editTextPreference.getText()!=null && editTextPreference.getText().equals("")) || (editTextPreference.getText()==null)){
-                editTextPreference.setTitle("> " + getResources().getString(R.string.setting_enter_userAgent) + " <");
-            }
-        }
-
        findPreference("settings_filter").setOnPreferenceClickListener(preference -> {
            Intent intent = new Intent(getActivity(), Settings_Filter.class);
            requireActivity().startActivity(intent);
@@ -119,7 +111,7 @@ public class Fragment_settings extends PreferenceFragmentCompat implements Share
             if (p.getTitle().toString().toLowerCase().contains("password")) {
                 p.setSummary("******");
             } else {
-                p.setSummary(editTextPref.getText());
+                if (p.getSummaryProvider()==null)   p.setSummary(editTextPref.getText());
             }
         }
         if (p instanceof MultiSelectListPreference) {
@@ -132,19 +124,6 @@ public class Fragment_settings extends PreferenceFragmentCompat implements Share
     public void onSharedPreferenceChanged(final SharedPreferences sp, String key) {
         if (key.equals("userAgent") || key.equals("sp_search_engine_custom") || key.equals("@string/sp_search_engine")) {
             sp.edit().putInt("restart_changed", 1).apply();
-            if (key.equals("userAgent") && !Objects.equals(sp.getString("userAgent", ""), "")) {
-                androidx.preference.EditTextPreference editTextPreference = findPreference("userAgent");
-                if (editTextPreference != null) {
-                    editTextPreference.setTitle("");
-                    editTextPreference.setEnabled(true);
-                }
-            }else{
-                androidx.preference.EditTextPreference editTextPreference = findPreference("userAgent");
-                if (editTextPreference != null) {
-                    editTextPreference.setTitle("> " + getResources().getString(R.string.setting_enter_userAgent) + " <");
-                    editTextPreference.setEnabled(true);
-                }
-            }
             updatePrefSummary(findPreference(key));
         }
     }

--- a/app/src/main/java/de/baumann/browser/preferences/EditTextSwitchPreference.java
+++ b/app/src/main/java/de/baumann/browser/preferences/EditTextSwitchPreference.java
@@ -1,0 +1,60 @@
+package de.baumann.browser.preferences;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.view.ViewGroup;
+import android.widget.CompoundButton;
+
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.preference.EditTextPreference;
+import androidx.preference.PreferenceManager;
+import androidx.preference.PreferenceViewHolder;
+
+import de.baumann.browser.R;
+
+public class EditTextSwitchPreference extends EditTextPreference {
+
+    private String EditTextSwitchKey;
+    private boolean EditTextSwitchKeyDefaultValue;
+    private boolean switchAttached=false;
+
+    public EditTextSwitchPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        EditTextSwitchKey=null;
+        EditTextSwitchKeyDefaultValue=false;
+        TypedArray valueArray;
+        if(attrs != null)
+        {
+            valueArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.EditTextSwitchPreference, 0, 0);
+            EditTextSwitchKey = valueArray.getString(R.styleable.EditTextSwitchPreference_editTextSwitchKey);
+            EditTextSwitchKeyDefaultValue = valueArray.getBoolean(R.styleable.EditTextSwitchPreference_editTextSwitchKeyDefaultValue,false);
+            valueArray.recycle();
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        final SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getContext());
+        final ViewGroup rootView;
+        final SwitchCompat onOffSwitch;
+        final CompoundButton.OnCheckedChangeListener checkedChangeListener;
+        super.onBindViewHolder(holder);
+        rootView = (ViewGroup)holder.itemView;
+        if (!switchAttached&&(EditTextSwitchKey!=null)){
+            onOffSwitch=new SwitchCompat(getContext());
+            rootView.addView(onOffSwitch);
+            switchAttached=true;
+            onOffSwitch.setChecked(sp.getBoolean(EditTextSwitchKey,EditTextSwitchKeyDefaultValue));
+            checkedChangeListener = (buttonView, isChecked) -> {
+                if(EditTextSwitchKey != null)
+                {
+                    sp.edit().putBoolean(EditTextSwitchKey, isChecked).apply();
+                }
+            };
+            onOffSwitch.setOnCheckedChangeListener(checkedChangeListener);
+            checkedChangeListener.onCheckedChanged(onOffSwitch, onOffSwitch.isChecked());
+        }
+    }
+}

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -9,4 +9,8 @@
         <attr name="hint" format="string"/>
         <attr name="showSwitch" format="boolean"/>
     </declare-styleable>
+    <declare-styleable name="EditTextSwitchPreference">
+        <attr name="editTextSwitchKey" format="string"/>
+        <attr name="editTextSwitchKeyDefaultValue" format="boolean" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/xml/preference_filter.xml
+++ b/app/src/main/res/xml/preference_filter.xml
@@ -7,60 +7,82 @@
         app:iconSpaceReserved="false"
         android:summary="@string/setting_gesture_hint"/>
 
-    <de.baumann.browser.preferences.SwitchTextPreference
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_01"
-        app:defaultText="@string/color_red"
-        app:switchKey="filter_01"
-        app:icon="@drawable/circle_red_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_red"
+        app:editTextSwitchKey="filter_01"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_red_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_02"
-        app:defaultText="@string/color_pink"
-        app:switchKey="filter_02"
-        app:icon="@drawable/circle_pink_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_pink"
+        app:editTextSwitchKey="filter_02"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_pink_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_03"
-        app:defaultText="@string/color_purple"
-        app:switchKey="filter_03"
-        app:icon="@drawable/circle_purple_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_purple"
+        app:editTextSwitchKey="filter_03"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_purple_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_04"
-        app:defaultText="@string/color_blue"
-        app:switchKey="filter_04"
-        app:icon="@drawable/circle_blue_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_blue"
+        app:editTextSwitchKey="filter_04"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_blue_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_05"
-        app:defaultText="@string/color_teal"
-        app:switchKey="filter_05"
-        app:icon="@drawable/circle_teal_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_teal"
+        app:editTextSwitchKey="filter_05"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_teal_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_06"
-        app:defaultText="@string/color_green"
-        app:switchKey="filter_06"
-        app:icon="@drawable/circle_green_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_green"
+        app:editTextSwitchKey="filter_06"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_green_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_07"
-        app:defaultText="@string/color_lime"
-        app:switchKey="filter_07"
-        app:icon="@drawable/circle_lime_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_lime"
+        app:editTextSwitchKey="filter_07"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_lime_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_08"
-        app:defaultText="@string/color_yellow"
-        app:switchKey="filter_08"
-        app:icon="@drawable/circle_yellow_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_yellow"
+        app:editTextSwitchKey="filter_08"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_yellow_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_09"
-        app:defaultText="@string/color_orange"
-        app:switchKey="filter_09"
-        app:icon="@drawable/circle_orange_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_orange"
+        app:editTextSwitchKey="filter_09"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_orange_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_10"
-        app:defaultText="@string/color_brown"
-        app:switchKey="filter_10"
-        app:icon="@drawable/circle_brown_big" />
-    <de.baumann.browser.preferences.SwitchTextPreference
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_brown"
+        app:editTextSwitchKey="filter_10"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_brown_big" />
+    <de.baumann.browser.preferences.EditTextSwitchPreference
         android:key="icon_11"
-        app:defaultText="@string/color_grey"
-        app:switchKey="filter_11"
-        app:icon="@drawable/circle_grey_big" />
+        app:useSimpleSummaryProvider="true"
+        android:defaultValue="@string/color_grey"
+        app:editTextSwitchKey="filter_11"
+        app:editTextSwitchKeyDefaultValue="true"
+        android:icon="@drawable/circle_grey_big" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preference_setting.xml
+++ b/app/src/main/res/xml/preference_setting.xml
@@ -40,14 +40,14 @@
         <Preference
             android:key="settings_data"
             android:title="@string/setting_title_data"/>
-        <SwitchPreference
-            android:title="@string/setting_title_userAgent"
-            android:key="userAgentSwitch"   />
-        <EditTextPreference
-            android:dependency="userAgentSwitch"
+
+        <de.baumann.browser.preferences.EditTextSwitchPreference
             android:selectable="true"
+            app:useSimpleSummaryProvider="true"
             android:key="userAgent"
-            android:title="" />
+            app:editTextSwitchKey="userAgentSwitch"
+            android:title="@string/setting_title_userAgent" />
+
         <EditTextPreference
             android:defaultValue="https://www.ecosia.org/search?q="
             android:key="sp_search_engine_custom"


### PR DESCRIPTION
I wrote a better (in my view) EditTextSwitchPreference for userAgent and filter settings.
It does not need a separate layout file and just appends a switch to the "normal" EditTextPreference.
So it should be much less sensitive to layout stuff.