### PR TITLE
Fix problem for downloading DataUri on Android11

### DIFF
--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -1485,7 +1485,7 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
                 case 4:
                     if (url.startsWith("data:")) {
                         DataURIParser dataURIParser= new DataURIParser(url);
-                        HelperUnit.saveDataURI(dialog, activity, dataURIParser);
+                        HelperUnit.saveDataURI(dialog, context, activity, dataURIParser);
                     } else HelperUnit.saveAs(dialog, activity, url);
                     break;
                 case 5:

--- a/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
+++ b/app/src/main/java/de/baumann/browser/unit/BrowserUnit.java
@@ -175,8 +175,7 @@ public class BrowserUnit {
                 String filename = URLUtil.guessFileName(url, contentDisposition, mimeType); // Maybe unexpected filename.
                 if (url.startsWith("data:")) {
                     DataURIParser dataURIParser = new DataURIParser(url);
-                    Activity activity = (Activity) context;
-                    if (HelperUnit.hasPermissionStorage(activity)) {
+                    if (HelperUnit.checkPermission(context)) {
                         File file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), filename);
                         FileOutputStream fos = new FileOutputStream(file);
                         fos.write(dataURIParser.getImagedata());

--- a/app/src/main/java/de/baumann/browser/unit/HelperUnit.java
+++ b/app/src/main/java/de/baumann/browser/unit/HelperUnit.java
@@ -71,6 +71,7 @@ import java.util.concurrent.Executors;
 
 import de.baumann.browser.R;
 import de.baumann.browser.browser.DataURIParser;
+import de.baumann.browser.fragment.Fragment_settings_Backup;
 import de.baumann.browser.view.GridItem;
 import de.baumann.browser.view.NinjaToast;
 
@@ -453,7 +454,7 @@ public class HelperUnit {
         });
     }
 
-    public static void saveDataURI(AlertDialog dialogToCancel, Activity activity, DataURIParser dataUriParser) {
+    public static void saveDataURI(AlertDialog dialogToCancel,Context context, Activity activity, DataURIParser dataUriParser) {
 
         byte[] imagedata = dataUriParser.getImagedata();
         String filename=dataUriParser.getFilename();
@@ -482,7 +483,7 @@ public class HelperUnit {
             if (title.isEmpty() || extension1.isEmpty() || !extension1.startsWith(".")) {
                 NinjaToast.show(activity, activity.getString(R.string.toast_input_empty));
             } else {
-                if (HelperUnit.hasPermissionStorage(activity)) {
+                if (HelperUnit.checkPermission(context)) {
                     File file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), filename1);
                     try {FileOutputStream fos = new FileOutputStream(file);
                         fos.write(imagedata);
@@ -491,7 +492,9 @@ public class HelperUnit {
                         e.printStackTrace();
                     }
                     dialogToCancel.cancel();
-                }else System.out.println("Error Downloading File: no storage permission ");
+                }else {
+                    System.out.println("Error Downloading File: no storage permission ");
+                }
             }
         });
         builder.setNegativeButton(R.string.app_cancel, (dialog, whichButton) -> builder.setCancelable(true));


### PR DESCRIPTION
I tested the latest version again. Now on Android 11 I can export my bookmarks. Downloading DataURIs did not work anymore.
With the changes of this commit it works again, but only if permissions have already been granted previously.
I do not how how to request permissions from HelperUnit because I would need someActivityResultLauncher.
requestPermission(context,activity,Fragment_settings_Backup.someActivityResultLauncher); is not allowed
(Non-static field 'someActivityResultLauncher' cannot be referenced from a static context)...

On Android 10 exporting bookmarks does not work. It opens a popup and tells me that FOSS Browser needs Permission...
If I click "OK" nothing happens. At next click the popup will open again and again.

But it works if we increase         android:maxSdkVersion="29" instead of "28" (not included in this commit).
Then I have to first revoke the permission in phone settings, then it will be requested again and works.
Also for DataURIs.

Probably the hasPermissionStorage method has to replaced by checkPermission throughout the whole app, right?
