### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -34,7 +34,7 @@
     <string name="main_omnibox_input_hint">Rechercher ou taper une URL</string>
     <string name="menu_open_with">Ouvrir le lien avec …</string>
     <string name="menu_quit">Quitter</string>
-    <string name="menu_openFav">Ouvrir les favoris</string>
+    <string name="menu_openFav">Ouvrir l'Accueil</string>
     <string name="menu_delete">Effacer</string>
     <string name="menu_edit">Editer</string>
     <string name="menu_closeTab">Fermer l\'onglet</string>


### PR DESCRIPTION
translation mistake. this menu opens the home page (URL Home) and do not open the window where there are all the favorites
menu_openFav:   Open Favorite = Ouvrir l'Accueil
(error with "Ouvrir les favoris" )