### PR TITLE
Simplify setFavicon

### DIFF
--- a/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
+++ b/app/src/main/java/de/baumann/browser/view/NinjaWebView.java
@@ -658,32 +658,13 @@ public class NinjaWebView extends WebView implements AlbumController {
         RecordAction action = new RecordAction(context);
         action.open(false);
         List<Record> list;
-        list = action.listBookmark(context, false, 0);
+        list = action.listEntries((Activity) context);
         action.close();
         for (Record listItem: list){
             if(listItem.getURL().equals(getUrl())){
                 if (faviconHelper.getFavicon(listItem.getURL())==null) faviconHelper.addFavicon(getUrl(),getFavicon());
             }
         }
-
-        action.open(false);
-        list = action.listStartSite((Activity) context);
-        action.close();
-        for (Record listItem: list){
-            if(listItem.getURL().equals(getUrl())){
-                if (faviconHelper.getFavicon(listItem.getURL())==null) faviconHelper.addFavicon(getUrl(),getFavicon());
-            }
-        }
-
-        action.open(false);
-        list = action.listHistory();
-        action.close();
-        for (Record listitem: list){
-            if(listitem.getURL().equals(getUrl())){
-                if (faviconHelper.getFavicon(listitem.getURL())==null) faviconHelper.addFavicon(getUrl(),getFavicon());
-            }
-        }
-
     }
 
     @Nullable


### PR DESCRIPTION
I simplified setFavicon in NinjaWebView. In the past we did not check for history items. 
At the moment we are opening the database 3 times to request the lists (bookmarks, start site, history) but we can do it with one call of listEntries.
Maybe that causes the web site crash #665 
In the latest log there is a lot of favicon stuff (onIconReceived, setFavicon,...)

Just an idea, but it is anyway a good thing to simplify the code
