### PR TITLE
Add support for intent scheme URLs again 

### DIFF
--- a/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
+++ b/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
@@ -461,6 +461,9 @@ public class NinjaWebViewClient extends WebViewClient {
                 Intent intent;
                 if (url.startsWith("intent:")) {
                     intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+                    intent.addCategory("android.intent.category.BROWSABLE");
+                    intent.setComponent(null);
+                    intent.setSelector(null);
                 } else {
                     intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                 }

--- a/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
+++ b/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
@@ -458,7 +458,12 @@ public class NinjaWebViewClient extends WebViewClient {
             String url = uri.toString();
             if (url.startsWith("http://") || url.startsWith("https://")) return false;
             try {
-                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                Intent intent;
+                if (url.startsWith("intent:")) {
+                    intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+                } else {
+                    intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                }
                 view.getContext().startActivity(intent);
                 return true;
             } catch (Exception e) {


### PR DESCRIPTION
Currently nothing happens when trying to open a URL starting with `intent:`.
This seems to have been removed in https://github.com/scoute-dich/browser/commit/9dd7ef7a20f791fa40a1639b5602072aa3fbe83e.
Would you consider supporting such URLs again? This allows opening content in apps even if no custom URL scheme (like `youtube:`) is specified. This affects for example websites that offer to open audio/video files with external apps.

See also: https://developer.chrome.com/docs/multidevice/android/intents/

This small change allows the app to handle them again, but it does not account for a fallback url as the previous version (before https://github.com/scoute-dich/browser/commit/9dd7ef7a20f791fa40a1639b5602072aa3fbe83e) did.