### PR TITLE
Restored functionality to proceed according to user selection broken by previous commit ad2c9f086b69d8c94e9a6ead0f892e34089c97f0.

### DIFF
--- a/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
+++ b/app/src/main/java/de/baumann/browser/browser/NinjaWebViewClient.java
@@ -520,7 +520,7 @@ public class NinjaWebViewClient extends WebViewClient {
         builder.setIcon(R.drawable.icon_alert);
         builder.setTitle(R.string.app_warning);
         builder.setMessage(text);
-        builder.setPositiveButton(R.string.app_ok, (dialog, whichButton) -> handler.cancel());
+        builder.setPositiveButton(R.string.app_ok, (dialog, whichButton) -> handler.proceed());
         builder.setNegativeButton(R.string.app_cancel, (dialog, whichButton) -> dialog.cancel());
         AlertDialog dialog = builder.create();
         dialog.show();


### PR DESCRIPTION
Previous commit ad2c9f086b69d8c94e9a6ead0f892e34089c97f0 did a bunch of stylistic and functional changes, including the functional change causing the UI to ignore user selection to proceed anyway with a not trusted certificate.

I believe that was a regression, as that commit left the UI logic asking the user if they want to proceed or not in place, but broke the logic handling their selection choice.  This commit restores this user selection handling logic.