### PR TITLE
Fix opening url from outside.

### DIFF
--- a/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
+++ b/app/src/main/java/de/baumann/browser/activity/BrowserActivity.java
@@ -300,6 +300,8 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
         initSearchPanel();
         initOverview();
 
+        dispatchIntent(getIntent());
+
         //restore open Tabs from shared preferences if app got killed
         if (sp.getBoolean("sp_restoreTabs", false)
                 || sp.getBoolean("sp_reloadTabs", false)
@@ -318,7 +320,11 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
             sp.edit().putBoolean("restoreOnRestart", false).apply();
         }
 
-        dispatchIntent(getIntent());
+        //if still no open Tab open default page
+        if (BrowserContainer.size() < 1) {
+            if (sp.getBoolean("start_tabStart", false)) showOverview();
+            addAlbum(getString(R.string.app_name), Objects.requireNonNull(sp.getString("favoriteURL", "https://github.com/scoute-dich/browser/blob/master/README.md")), true, false, "");
+        }
     }
 
     @Override
@@ -2224,13 +2230,6 @@ public class BrowserActivity extends AppCompatActivity implements BrowserControl
             getIntent().setAction("");
             hideOverview();
             BrowserUnit.openInBackground(activity, intent, data);
-        }
-
-        //if still no open Tab open default page
-        if (BrowserContainer.size() < 1) {
-            if (sp.getBoolean("start_tabStart", false)) showOverview();
-            addAlbum(getString(R.string.app_name), Objects.requireNonNull(sp.getString("favoriteURL", "https://github.com/scoute-dich/browser/blob/master/README.md")), true, false, "");
-            getIntent().setAction("");
         }
     }
 


### PR DESCRIPTION
**The browser can't open URL from outside, if it was closed before.**

**Environments**
1. Phone: Xiaomi Mi 10T Pro, M2007J3SG; Android version: 12; MIUI version 13.0.5
2. Emulator: Galaxy Nexus API 30.

**Steps to Reproduce**
1. Close the browser by swiping it from recent
2. Try open a website from a external application 

**Actual Result**
The browser opens, but page is empty and tabs counter is hidden.
![bug](https://user-images.githubusercontent.com/78897971/183946551-2c962b5c-563d-4e80-8658-033d34731191.gif)

**Expected Result**
The browser opens, there is website on page and tabs counter is visible.
![fix](https://user-images.githubusercontent.com/78897971/183946590-6a7c6fd5-f85c-48eb-9111-4f27b9e5fb24.gif)

**The same issues**
- #969
- #874

**Reason**
When we call "contentFrame.removeAllViews()" in addAlbum() with intent url and foreground is true,
system call onFocusChange() with omniBox_text has focus. In listener WebView stop loading site
and don't reload after omniBox_text comes back unfocused.

**Solution**
Dispatch intent before restoring tabs in onCreate().