### PR TITLE
Use material dialogs in the preferences

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -188,7 +188,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -188,7 +188,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
 
 import java.util.Objects;
@@ -20,8 +19,9 @@ import de.baumann.browser.activity.Settings_Filter;
 import de.baumann.browser.activity.Settings_Gesture;
 import de.baumann.browser.activity.Settings_PrivacyActivity;
 import de.baumann.browser.activity.Settings_UI;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 
-public class Fragment_settings extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class Fragment_settings extends BasePreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Backup.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Backup.java
@@ -10,7 +10,6 @@ import android.os.Environment;
 import android.widget.Button;
 
 import androidx.appcompat.app.AlertDialog;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -34,11 +33,12 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import de.baumann.browser.R;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 import de.baumann.browser.unit.BackupUnit;
 import de.baumann.browser.unit.HelperUnit;
 import de.baumann.browser.view.NinjaToast;
 
-public class Fragment_settings_Backup extends PreferenceFragmentCompat {
+public class Fragment_settings_Backup extends BasePreferenceFragment {
 
     public File sd;
     public File data;

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Delete.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Delete.java
@@ -7,14 +7,14 @@ import android.os.Bundle;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import de.baumann.browser.R;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 import de.baumann.browser.unit.HelperUnit;
 
-public class Fragment_settings_Delete extends PreferenceFragmentCompat {
+public class Fragment_settings_Delete extends BasePreferenceFragment {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Filter.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Filter.java
@@ -2,11 +2,10 @@ package de.baumann.browser.fragment;
 
 import android.os.Bundle;
 
-import androidx.preference.PreferenceFragmentCompat;
-
 import de.baumann.browser.R;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 
-public class Fragment_settings_Filter extends PreferenceFragmentCompat {
+public class Fragment_settings_Filter extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.preference_filter, rootKey);

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Gesture.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Gesture.java
@@ -7,15 +7,15 @@ import android.os.Bundle;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceManager;
 
 import java.util.Objects;
 
 import de.baumann.browser.R;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 
-public class Fragment_settings_Gesture extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class Fragment_settings_Gesture extends BasePreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Privacy.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Privacy.java
@@ -14,7 +14,6 @@ import androidx.cardview.widget.CardView;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceManager;
 
@@ -28,10 +27,11 @@ import de.baumann.browser.R;
 import de.baumann.browser.activity.ProfilesList;
 import de.baumann.browser.activity.Settings_Profile;
 import de.baumann.browser.browser.AdBlock;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 import de.baumann.browser.view.GridAdapter;
 import de.baumann.browser.view.GridItem;
 
-public class Fragment_settings_Privacy extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class Fragment_settings_Privacy extends BasePreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Profile.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_Profile.java
@@ -4,14 +4,14 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
 import java.util.Objects;
 
 import de.baumann.browser.R;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 
-public class Fragment_settings_Profile extends PreferenceFragmentCompat {
+public class Fragment_settings_Profile extends BasePreferenceFragment {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_UI.java
+++ b/app/src/main/java/de/baumann/browser/fragment/Fragment_settings_UI.java
@@ -7,14 +7,14 @@ import android.os.Bundle;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
 
 import java.util.Objects;
 
 import de.baumann.browser.R;
+import de.baumann.browser.preferences.BasePreferenceFragment;
 
-public class Fragment_settings_UI extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class Fragment_settings_UI extends BasePreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/app/src/main/java/de/baumann/browser/preferences/BasePreferenceFragment.java
+++ b/app/src/main/java/de/baumann/browser/preferences/BasePreferenceFragment.java
@@ -1,0 +1,70 @@
+package de.baumann.browser.preferences;
+
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.EditTextPreference;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import de.baumann.browser.R;
+
+public class BasePreferenceFragment extends PreferenceFragmentCompat {
+    @Override
+    public void onCreatePreferences(@Nullable @org.jetbrains.annotations.Nullable Bundle savedInstanceState, @Nullable @org.jetbrains.annotations.Nullable String rootKey) {
+    }
+
+    @Override
+    public void onDisplayPreferenceDialog(@NonNull Preference preference) {
+        if (preference instanceof ListPreference) {
+            showListPreference((ListPreference) preference);
+        } else if (preference instanceof EditTextPreference) {
+            showEditTextPreference((EditTextPreference) preference);
+        } else {
+            super.onDisplayPreferenceDialog(preference);
+        }
+    }
+
+    public void showListPreference(@NonNull ListPreference preference) {
+        int selectionIndex = Arrays.asList(preference.getEntryValues()).indexOf(preference.getValue());
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireContext());
+        builder.setTitle(preference.getTitle());
+        builder.setNegativeButton(R.string.app_cancel, null);
+        builder.setSingleChoiceItems(preference.getEntries(), selectionIndex, (dialog, index) -> {
+            String newValue = preference.getEntryValues()[index].toString();
+            if (preference.callChangeListener(newValue)) {
+                preference.setValue(newValue);
+            }
+            dialog.dismiss();
+        });
+        builder.show();
+    }
+
+    public void showEditTextPreference(@NonNull EditTextPreference preference) {
+        View dialogView = View.inflate(getContext(), R.layout.dialog_edit_text, null);
+        TextInputEditText input = dialogView.findViewById(R.id.textInput);
+        input.setText(preference.getText());
+
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireContext());
+        builder.setTitle(preference.getTitle());
+        builder.setNegativeButton(R.string.app_cancel, null);
+        builder.setPositiveButton(R.string.app_ok, (dialog, i) -> {
+            String newValue = Objects.requireNonNull(input.getText()).toString();
+            if (preference.callChangeListener(newValue)) {
+                preference.setText(newValue);
+            }
+            dialog.dismiss();
+        });
+        builder.setView(dialogView);
+        builder.show();
+    }
+}

--- a/app/src/main/res/layout/dialog_edit_text.xml
+++ b/app/src/main/res/layout/dialog_edit_text.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/editTextLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="10dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/textInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionNext"
+            android:inputType="text" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>


### PR DESCRIPTION
Hey,
first of all thanks for all your work spent onto the project, the app is really awesome at its current state with the awesome MD3 integration :)

This PR will improve the design of the preference dialogs by using the `MaterialAlertDialogBuilder` when showing preferences instead of using the preference dialogs by the `androidx` library since the `material` library doesn't have its own implementation of the `PreferenceFragmentCompat`.
Affected preference dialogs are the dialog of the `ListPreference` as well as the `EditTextPreference`.

Best regards